### PR TITLE
Only shift if arguments are available.  (fixes dash, default sh on Debian).

### DIFF
--- a/borg-backup.sh
+++ b/borg-backup.sh
@@ -110,8 +110,8 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%MZ")
 nargs=$#
 cmd=${1-}
 backup=${2-}
-shift || true
-shift || true
+if [ "$#" -gt 0 ]; then shift; fi
+if [ "$#" -gt 0 ]; then shift; fi
 
 rc=0
 for B in $BACKUPS; do


### PR DESCRIPTION
Thanks for the pointer to the actual repository.

Pull request that fixes the shifting in `dash`.  The unchecked shifting failed unconditionally.