### PR TITLE
v0.8.0: Detailed help and change passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,32 +18,6 @@ Make a borg-backup.conf from the provided template, e.g:
     TARGET=backup@fancy-backup-server:/backups/${HOSTNAME}
     
     ###############################################################################
-    ## Mandatory: A passphrase to derive an encryption key from.
-    ##
-    ## Be wary of permissions on this file.
-    ##
-    PASSPHRASE='ambiguous antelope capacitor paperclip'
-    
-    ###############################################################################
-    ## Optional: Compression
-    ##
-    ## See 'borg help compression' for available options.
-    ##
-    ## This script defaults to zstd as of 0.7.0.
-    ##
-    COMPRESSION='zstd'
-    
-    ###############################################################################
-    ## Optional: Global prune configuration
-    ##
-    PRUNE='-H 24 -d 14 -w 8 -m 6'
-    
-    ###############################################################################
-    ## Optional: Compact threshold in percent
-    ##
-    COMPACT_THRESHOLD='10'
-    
-    ###############################################################################
     ## Mandatory: Backup name list
     ##
     BACKUPS='homes etc'
@@ -55,13 +29,48 @@ Make a borg-backup.conf from the provided template, e.g:
     ##
     BACKUP_homes='/home/freaky -e /home/freaky/Maildir/mutt-cache'
     BACKUP_etc='/etc /usr/local/etc'
+
+    ###############################################################################
+    ## Optional: Global prune configuration
+    ##
+    # PRUNE='-H 24 -d 14 -w 8 -m 6'
     
     ###############################################################################
     ## Optional: Per-backup prune configuration.
     ##
     ## These override the global configuration for individual backups.
     #
-    PRUNE_etc='--keep-hourly=72 --keep-daily=365'
+    # PRUNE_etc='--keep-hourly=72 --keep-daily=365'
+    
+    ###############################################################################
+    ## Optional: A passphrase to derive an encryption key from.
+    ##
+    ## Be wary of permissions on this file.
+    ##
+    # PASSPHRASE='ambiguous antelope capacitor paperclip'
+    ##
+    ## Or override the global password with individual
+    ##
+    # PASSPHRASE_homes='incorrect zebra generator clip'
+    
+    ###############################################################################
+    ## Optional: Compression
+    ##
+    ## See 'borg help compression' for available options.
+    ##
+    ## This script defaults to zstd as of 0.7.0.
+    ##
+    # COMPRESSION='zstd'
+    
+    ###############################################################################
+    ## Optional: Compact threshold in percent
+    ##
+    # COMPACT_THRESHOLD='10'
+    
+    ###############################################################################
+    ## Optional: Suffix for backups name
+    ##
+    # SUFFIX='.borg'
 
 
 This will produce two independent Borg archives.  If using a remote host over SSH,
@@ -106,6 +115,13 @@ Or the repository and the last archive:
 Or only the repository (a purely server-side check):
 
     $ borg-backup.sh repocheck
+
+To change passphrase if repo initialized with (note: global PASSPHRASE if set isn't remove)
+then new passphrase is added and old is removed from config.
+Also need to provide sudo privs while changing to authorize move new config to /etc.
+
+    $ borg-backup.sh changepass
+
 
 For any Borg operation not covered explicitly, borg-backup.sh provides a `borg`
 subcommand, which passes through the argument list to borg, having set up the

--- a/borg-backup.conf
+++ b/borg-backup.conf
@@ -4,51 +4,13 @@
 ## This file is sourced by the shell.
 
 ###############################################################################
-## Optional: Borg executable location
+## Optional: Borg executable location (whereis borg)
 # BORG=/usr/local/bin/borg
 
 ###############################################################################
 ## Mandatory: Target destination for backups. Directory must exist.
 ##
 # TARGET=backup@backuphost:/backups/${HOSTNAME}
-
-###############################################################################
-## Mandatory: A passphrase to derive an encryption key from.
-##
-## Be wary of permissions on this file.
-##
-# PASSPHRASE='incorrect zebra generator clip'
-
-## Some configurations meant only for interactive use might prefer:
-##
-# echo -n "Passphrase: " ; read -s PASSPHRASE
-
-## Or using lastpass-cli:
-##
-# PASSPHRASE=$(lpass show -p borg-backup)
-
-###############################################################################
-## Optional: Compression
-##
-## See 'borg help compression' for available options.
-##
-## This script defaults to zstd as of 0.7.0.
-##
-# COMPRESSION='zstd'
-
-###############################################################################
-## Optional: Global prune configuration
-##
-# PRUNE='-H 24 -d 14 -w 8 -m 6'
-#
-## Or for a more self-documenting config:
-##
-# PRUNE='--keep-hourly=24 --keep-daily=14 --keep-weekly=8 --keep-monthly=6'
-
-###############################################################################
-## Optional: Compact threshold in percent
-##
-# COMPACT_THRESHOLD='10'
 
 ###############################################################################
 ## Mandatory: Backup name list
@@ -64,8 +26,55 @@
 # BACKUP_etc='/etc /usr/local/etc'
 
 ###############################################################################
+## Optional: A passphrase to derive an encryption key from.
+##
+## Be wary of permissions on this file.
+##
+# PASSPHRASE='incorrect zebra generator clip'
+
+## Some configurations meant only for interactive use might prefer:
+##
+# echo -n "Passphrase: " ; read -s PASSPHRASE
+
+## Or using lastpass-cli:
+##
+# PASSPHRASE=$(lpass show -p borg-backup)
+
+## Or override the global password with individual
+##
+# PASSPHRASE_homes='incorrect zebra generator clip'
+
+###############################################################################
+## Optional: Global prune configuration
+##
+# PRUNE='-H 24 -d 14 -w 8 -m 6'
+#
+## Or for a more self-documenting config:
+##
+# PRUNE='--keep-hourly=24 --keep-daily=14 --keep-weekly=8 --keep-monthly=6'
+
+###############################################################################
 ## Optional: Per-backup prune configuration.
 ##
 ## These override the global configuration for individual backups.
 #
 # PRUNE_etc='--keep-hourly=72 --keep-daily=365'
+
+###############################################################################
+## Optional: Compression
+##
+## See 'borg help compression' for available options.
+##
+## This script defaults to zstd as of 0.7.0.
+##
+# COMPRESSION='zstd'
+
+###############################################################################
+## Optional: Suffix for backups name
+##
+# SUFFIX='.borg'
+
+###############################################################################
+## Optional: Compact threshold in percent
+##
+# COMPACT_THRESHOLD='10'

--- a/borg-backup.sh
+++ b/borg-backup.sh
@@ -139,7 +139,7 @@ for B in $BACKUPS; do
 		case $cmd in
 			init)
 				[ "$nargs" -gt 2 ] && usage 64
-				$BORG init --encryption=repokey || rc=$?
+				$BORG init --encryption=$REPOKEY || rc=$?
 			;;
 			create)
 				[ "$nargs" -gt 2 ] && usage 64


### PR DESCRIPTION
**NOTE:**
- .config 100% compatible with previews version
- shellcheck 100% valid
---

**0.7.1 : Added detailed help and none encryption**
---
Added detailed help to show:
- defined backup dirs
- if is more prunes
- encryption kind
- shorten executable name

If Passphrase is empty then apply NONE for encryption. No longer error display.

**0.8.0: change passphrase**
---
- rearanged .conf to meet mandatory first and important optional as second
- added option to change SUFFIX for repo name
- added passphrase to set for each repos
- added passphrase change, need provide sudo while change /etc/borg*.conf
- fixed help to show if global passphrase is set and/or for each repo